### PR TITLE
Update depend list for atom-shell-0.16.2

### DIFF
--- a/dev-util/atom-shell/atom-shell-0.16.2.ebuild
+++ b/dev-util/atom-shell/atom-shell-0.16.2.ebuild
@@ -36,6 +36,7 @@ DEPEND="
     gnome-base/gconf
     media-libs/alsa-lib
     net-print/cups
+    sys-libs/libcap
 "
 RDEPEND="${DEPEND}
     !<app-editors/atom-0.120.0


### PR DESCRIPTION
Fix error:
/usr/bin/x86_64-pc-linux-gnu-ld: warning: libcap.so.2, needed by /var/tmp/portage/dev-util/atom-shell-0.16.2/work/atom-shell-0.16.2/vendor/brightray/vendor/download/libchromiumcontent/Release/libchromiumcontent.so, not found (try using -rpath or -rpath-link)
